### PR TITLE
Correction de l'ordre des opérandes dans la fonction subtract

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -16,13 +16,13 @@ def subtract(a: float,b: float) -> float:
     Soustraction de deux nombres.
 
     Paramètres:
-        a (float): Nombre à soustraire.
-        b (float): Nombre duquel on soustrait.
+        a (float): Nombre duquel on soustrait.
+        b (float): Nombre à soustraire.
     
     Retour:
-        float: Résultat de b - a.
+        float: Résultat de a - b.
     '''
-    return b - a
+    return a - b
 
 def multiply(a: float,b: float) -> float:
     '''


### PR DESCRIPTION
**Cause du bogue:** Cette Pull Request corrige le bogue identifié. La fonction subtract retournait un résultat inversé (calculait *b - a* au lieu de *a - b*), ce qui provoquait des résultats négatifs erronés.

Validation du test: Le test unitaire *test_subtract* qui échouait précédemment passe maintenant avec succès.