### PR TITLE
Correction de l'opérateur de multiplication dans operators.py

### DIFF
--- a/operators.py
+++ b/operators.py
@@ -35,7 +35,7 @@ def multiply(a: float,b: float) -> float:
     Retour:
         float: Produit de a et b.
     '''
-    return a ** b
+    return a * b
 
 def divide(a: float,b: float) -> float:
     '''


### PR DESCRIPTION
Cette Pull Request corrige le bogue critique identifié dans la fonction multiply. La fonction *multiply(a, b)* retournait un résultat erroné (81 pour l'entrée 3, 4), ce qui indiquait une erreur dans l'opérateur arithmétique utilisé.

**Changement apporté:** Remplacement de *return a ** b* par *return a * b* dans le fichier *operators.py*

**Validation du test:** La suite de tests unitaires a été exécutée localement. Le test *test_multiply* passe désormais avec succès.